### PR TITLE
Fix: Resolve database connection pool exhaustion

### DIFF
--- a/app/db/session.py
+++ b/app/db/session.py
@@ -22,6 +22,8 @@ SQLALCHEMY_DATABASE_URL = f"sqlite:///{DB_PATH}"
 engine = create_engine(
     SQLALCHEMY_DATABASE_URL,
     connect_args={"check_same_thread": False},  # Needed for SQLite
+    pool_size=5,  # Number of connections to keep open in the pool
+    max_overflow=10,  # Number of connections that can be opened beyond pool_size
 )
 
 # Create sessionmaker

--- a/app/main.py
+++ b/app/main.py
@@ -7,7 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.core.logging import setup_logging
 from app.core.exceptions import setup_exception_handlers
-from app.db.session import get_db, engine, Base
+from app.db.session import get_db, engine, Base, SessionLocal
 from app.services.scheduler import Scheduler
 from app.api.routes import router
 from app.core.settings import MONITORING_INTERVAL
@@ -108,12 +108,17 @@ async def initialize_background_tasks():
     )
 
 
+# Background Task Session Management:
+# The following asynchronous functions are periodically executed as background tasks.
+# Unlike FastAPI path operations that use dependency injection (e.g., Depends(get_db)),
+# these tasks require manual database session management.
+# Each task obtains a session directly using SessionLocal() and ensures it's closed
+# in a try/finally block to prevent connection leaks.
+
 async def initialize_bots():
     """Initialize bot population."""
+    db = SessionLocal()
     try:
-        # Get database session
-        db = next(get_db())
-
         # Create services
         content_generator = ContentGenerator()
         api_client = CartoucheAPIClient()
@@ -137,14 +142,14 @@ async def initialize_bots():
 
     except Exception as e:
         logger.error(f"Failed to initialize bots: {str(e)}")
+    finally:
+        db.close()
 
 
 async def daily_bot_growth():
     """Handle daily growth of bot population."""
+    db = SessionLocal()
     try:
-        # Get database session
-        db = next(get_db())
-
         # Create services
         content_generator = ContentGenerator()
         api_client = CartoucheAPIClient()
@@ -168,12 +173,14 @@ async def daily_bot_growth():
 
     except Exception as e:
         logger.error(f"Failed to handle daily bot growth: {str(e)}")
+    finally:
+        db.close()
 
 
 async def run_due_bot_activities():
     """Run due bot activities for all bots whose time has come."""
+    db = SessionLocal()
     try:
-        db = next(get_db())
         content_generator = ContentGenerator()
         api_client = CartoucheAPIClient()
         bot_repository = BotRepository(db)
@@ -193,14 +200,16 @@ async def run_due_bot_activities():
             logger.info("Ran due bot activities for all bots")
     except Exception as e:
         logger.error(f"Failed to run due bot activities: {str(e)}")
+    finally:
+        db.close()
 
 
 async def sync_bots_with_external_api_task():
     """
     Background task for syncing bots with external API.
     """
+    db = SessionLocal()
     try:
-        db = next(get_db())
         content_generator = ContentGenerator()
         api_client = CartoucheAPIClient()
         bot_repository = BotRepository(db)
@@ -220,6 +229,8 @@ async def sync_bots_with_external_api_task():
             logger.info(f"Synchronized {synced} bots with external API")
     except Exception as e:
         logger.error(f"Failed to sync bots with external API: {str(e)}")
+    finally:
+        db.close()
 
 
 @app.get("/")


### PR DESCRIPTION
The service was experiencing SQLAlchemy QueuePool overflow errors due to improper database session management in background tasks. Sessions obtained were not being reliably closed.

This commit addresses the issue by:
1. Modifying background tasks in `app/main.py` (`initialize_bots`, `daily_bot_growth`, `run_due_bot_activities`, `sync_bots_with_external_api_task`) to acquire a database session directly from `SessionLocal()` and ensure `db.close()` is called within a `finally` block. This guarantees that sessions are returned to the pool after task completion.
2. Explicitly setting `pool_size=5` and `max_overflow=10` (SQLAlchemy defaults) in the `create_engine` call in `app/db/session.py` for clarity and easier future tuning.
3. Adding comments in `app/main.py` and `app/db/session.py` to explain the session management strategies for background tasks versus FastAPI dependency injection.