### PR TITLE
Fix: Ensure mobile header has full width

### DIFF
--- a/social-network/network/static/network/styles.css
+++ b/social-network/network/static/network/styles.css
@@ -193,3 +193,9 @@ body>.row {
         overflow-y: scroll;
     }
 }
+
+/* Fix for mobile header width */
+nav.d-md-none {
+    width: 100%;
+    box-sizing: border-box;
+}


### PR DESCRIPTION
The mobile navigation bar (displayed on smaller screens) was sometimes not occupying the full available width, leading to an inconsistent appearance, especially on pages with little content.

This change adds a CSS rule to `styles.css` targeting the mobile navigation bar (`nav.d-md-none`) to set its `width` to `100%` and `box-sizing` to `border-box`. This ensures the header consistently spans the full width of the viewport on mobile devices, providing a more stable and visually appealing layout.

The `box-sizing: border-box;` property ensures that padding and borders do not increase the overall width of the element beyond 100%.